### PR TITLE
[WIP] fix inline procs

### DIFF
--- a/tests/config.nims
+++ b/tests/config.nims
@@ -1,3 +1,4 @@
 --define:"HippoRuntime:HIP_CPU"
 #--define:"HippoRuntime:SIMPLE"
 --path:"../src"
+--stackTrace:off

--- a/tests/test_dot_product.nim
+++ b/tests/test_dot_product.nim
@@ -18,8 +18,8 @@ proc dot(a, b, c: ptr[float64]){.hippoGlobal.} =
   var temp: float64 = 0
   while tid < N:
     # TODO not sure how to handle functions like `pluseq___dot_u17` with nim / cuda
-    #temp += aArray[tid] * bArray[tid]
-    temp = temp + (aArray[tid] * bArray[tid])
+    temp += aArray[tid] * bArray[tid]
+    #temp = temp + (aArray[tid] * bArray[tid])
     tid += blockDim.x * gridDim.x
   
   # set the cache values
@@ -34,8 +34,8 @@ proc dot(a, b, c: ptr[float64]){.hippoGlobal.} =
   while i != 0:
     if cacheIndex < i:
       # TODO not sure how to handle functions like `pluseq___dot_u17` with nim / cuda
-      #cache[cacheIndex] += cache[cacheIndex + i]
-      cache[cacheIndex] = cache[cacheIndex] + cache[cacheIndex + i]
+      cache[cacheIndex] += cache[cacheIndex + i]
+      #cache[cacheIndex] = cache[cacheIndex] + cache[cacheIndex + i]
     hippoSyncthreads()
     i = i div 2
 


### PR DESCRIPTION
- no actual fix yet, just defining the problem

- the issue does not reproduce on HIP-CPU or SIMPLE backends because they are not picky about device functions. this is expected.

- this issue reproduces on both AMD and on NVIDIA (different error messages of course but same underlying trickyness)

```
/home/monofuel/.cache/nim/test_dot_product_d/@zgrfg_qbg_cebqhpg.nim.cpp:340:4: error: no matching function for call to 'pluseq___cherZfgehgvyf_u2605'
  340 |                         pluseq___cherZfgehgvyf_u2605((*(&temp_1)), ((NF)(aArray_1[tid_1]) * (NF)(bArray_1[tid_1])));
      |                         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
/home/monofuel/.cache/nim/test_dot_product_d/@zgrfg_qbg_cebqhpg.nim.cpp:324:23: note: candidate function not viable: call to __host__ function from __global__ function
  324 | static N_INLINE(void, pluseq___cherZfgehgvyf_u2605)(NF& x_p0, NF y_p1) {
```

- I have a few theoretical solutions?
- option A: somehow get these inline functions annotated as `__host__` `__device__` so they will work anywhere.
- option B: convince the nim compiler to not use fancy inline functions like this.  not sure if there's an easy switch or not.
- option C: could we somehow traverse the function tree and automatically annotate functions? this would have to happen near the end of the compiling process. This could tie into the `hippoAutoGlobal` pragma that I've wanted. annotate a function as auto global and have it automatically annotate all sub functions as `__host__` `__device__`

- `inline` functions are totally great and work on GPU, they just need to be annotated `__device__` (or `__host__` `__device__`)